### PR TITLE
Assign rules to ROD

### DIFF
--- a/src/3DCurator.cpp
+++ b/src/3DCurator.cpp
@@ -6,7 +6,7 @@
 
 #include "GUI/MainWindow.h"
 
-#define RELEASE
+//#define RELEASE
 
 #ifdef RELEASE
 #define WINAPI __stdcall

--- a/src/Documentation/ROD.cpp
+++ b/src/Documentation/ROD.cpp
@@ -1,6 +1,6 @@
 #include "ROD.h"
 
-ROD::ROD(const std::string name, const double* origin, const double* point1, const double* point2, const double slice) {
+ROD::ROD(const std::string name, const double* origin, const double* point1, const double* point2, const double slice, const QFont enabled, const QFont disabled) {
 	this->name = name;
 	this->slice = slice;
 
@@ -17,6 +17,9 @@ ROD::ROD(const std::string name, const double* origin, const double* point1, con
 	this->point2[0] = point2[0];
 	this->point2[1] = point2[1];
 	this->point2[2] = point2[2];
+
+	this->enabled = enabled;
+	this->disabled = disabled;
 }
 
 std::string ROD::getName() const {
@@ -52,6 +55,56 @@ std::map<double*, std::string> ROD::getAnnotations() const {
 
 void ROD::setName(const std::string name) {
 	this->name = name;
+}
+
+void ROD::addRule(QListWidgetItem* item, vtkSmartPointer<vtkRenderWindowInteractor> interactor) {
+	rules[item] = vtkSmartPointer<vtkDistanceWidget>::New();
+	rules[item]->SetInteractor(interactor);
+	rules[item]->CreateDefaultRepresentation();
+	static_cast<vtkDistanceRepresentation *>(rules[item]->GetRepresentation())->SetLabelFormat("%-#6.3g mm");
+	rules[item]->On();
+}
+
+void ROD::deleteRule(QListWidgetItem* item) {
+	rules.erase(item);
+}
+
+void ROD::enableRule(QListWidgetItem* item) {
+	item->setFont(enabled);
+	rules[item]->On();
+}
+
+void ROD::disableRule(QListWidgetItem* item) {
+	item->setFont(disabled);
+	rules[item]->Off();
+}
+
+void ROD::enableDisableRule(QListWidgetItem* item) {
+	if (item->font() == disabled) {
+		enableRule(item);
+		item->setFont(enabled);
+	} else {
+		disableRule(item);
+		item->setFont(disabled);
+	}
+}
+
+void ROD::hideAllRules() {
+	std::map<QListWidgetItem*, vtkSmartPointer<vtkDistanceWidget>>::iterator it;
+	for (it = rules.begin(); it != rules.end(); ++it) {
+		it->first->setHidden(true);
+		it->second->Off();
+	}
+}
+
+void ROD::showAllRules() {
+	std::map<QListWidgetItem*, vtkSmartPointer<vtkDistanceWidget>>::iterator it;
+	for (it = rules.begin(); it != rules.end(); ++it) {
+		it->first->setHidden(false);
+		if (it->first->font() == enabled) {
+			it->second->On();
+		}
+	}
 }
 
 void ROD::clearAllRules() {

--- a/src/Documentation/ROD.h
+++ b/src/Documentation/ROD.h
@@ -2,6 +2,7 @@
 #define ROD_H
 
 #include <QListWidget>
+#include <QFont>
 
 #include <string>
 #include <map>
@@ -9,19 +10,23 @@
 
 #include <vtkSmartPointer.h>
 #include <vtkDistanceWidget.h>
+#include <vtkDistanceRepresentation.h>
+#include <vtkRenderWindowInteractor.h>
 #include <vtkAngleWidget.h>
 
 class ROD {
 public:
 	/**
 	 * Constructor
-	 * @param	name	ROD name
-	 * @param	origin	Origin of the plane
-	 * @param	point1	Position of the point defining the first axis of the plane
-	 * @param	point2	Position of the point defining the second axis of the plane
-	 * @param	slice	Slice position in terms of data extent
+	 * @param	name		ROD name
+	 * @param	origin		Origin of the plane
+	 * @param	point1		Position of the point defining the first axis of the plane
+	 * @param	point2		Position of the point defining the second axis of the plane
+	 * @param	slice		Slice position in terms of data extent
+	 * @param	enabled		Font for enabled list elements
+	 * @param	disabled	Font for disabled list elements
 	 */
-	ROD(const std::string name, const double* origin, const double* point1, const double* point2, const double slice);
+	ROD(const std::string name, const double* origin, const double* point1, const double* point2, const double slice, const QFont enabled, const QFont disabled);
 
 	/**
 	 * Get ROD name
@@ -78,6 +83,46 @@ public:
 	void setName(const std::string name);
 
 	/**
+	 * Add new rule to measure
+	 * @param	item	Rule item in UI
+	 */
+	void addRule(QListWidgetItem* item, vtkSmartPointer<vtkRenderWindowInteractor> interactor);
+
+	/**
+	 * Delete selected rule
+	 * @param	item	Rule item in UI
+	 */
+	void deleteRule(QListWidgetItem* item);
+
+	/**
+	 * Enable or disable selected rule
+	 * @param	item	Rule item in UI
+	 */
+	void enableDisableRule(QListWidgetItem* item);
+
+	/**
+	 * Enable selected rule
+	 * @param	item	Rule item in UI
+	 */
+	void enableRule(QListWidgetItem* item);
+
+	/**
+	 * Disable selected rule
+	 * @param	item	Rule item in UI
+	 */
+	void disableRule(QListWidgetItem* item);
+
+	/**
+	 * Hide all rules
+	 */
+	void hideAllRules();
+
+	/**
+	 * Show all rules
+	 */
+	void showAllRules();
+
+	/**
 	 * Delete all rules
 	 */
 	void clearAllRules();
@@ -101,6 +146,9 @@ private:
 	std::map<QListWidgetItem*, vtkSmartPointer<vtkDistanceWidget> > rules; /**< Rules container */
 	std::map<QListWidgetItem*, vtkSmartPointer<vtkAngleWidget> > protractors; /**< Rules container */
 	std::map<double*, std::string> annotations; /**< Annotations container */
+
+	QFont enabled; /**< Font for list enabled elements */
+	QFont disabled; /**< Font for list disabled elements */
 };
 
 #endif

--- a/src/GUI/mainwindow.h
+++ b/src/GUI/mainwindow.h
@@ -123,6 +123,7 @@ private slots:
 	void on_deleteRule_pressed();
 	void on_enableDisableRule_pressed();
 	void on_addROD_pressed();
+	void on_deleteROD_pressed();
 
 	void on_RODList_currentItemChanged();
 
@@ -356,9 +357,9 @@ private slots:
 	void launchWarningNoRule();
 
 	/**
-	 * Launch a warning message saying there are already too many rules
+	 * Launch a warning message saying there is no ROD selected
 	 */
-	void launchWarningTooManyRules();
+	void launchWarningNoActiveROD();
 
 	/**
 	 * Change background color of a viewer
@@ -383,9 +384,19 @@ private slots:
 	void setActiveROD(ROD *rod);
 
 	/**
+	 * Unset the active ROD
+	 */
+	void unsetActiveROD();
+
+	/**
 	 * Add new ROD
 	 */
 	void addROD();
+
+	/**
+	 * Delete active ROD
+	 */
+	void deleteROD();
 
 	/**
 	 * Add new rule to measure
@@ -401,16 +412,6 @@ private slots:
 	 * Enable or disable selected rule
 	 */
 	void enableDisableRule();
-
-	/**
-	 * Enable selected rule
-	 */
-	void enableRule();
-
-	/**
-	 * Disable selected rule
-	 */
-	void disableRule();
 
 	/**
 	 * Delete all rules
@@ -435,8 +436,6 @@ private:
 	OpacityTFChart *gradientTFChart; /**< Gradient transfer function chart pointer */
 
 	ROD *activeROD; /**< ROD currently active */
-
-	std::map<QListWidgetItem*, vtkSmartPointer<vtkDistanceWidget> > rules; /**< Rules container */
 	std::map<QListWidgetItem*, ROD*> rods; /**< RODs counter */
 
 	vtkSmartPointer<vtkRenderer> volumeRen; /**< Volume and slice plane renderer pointer */
@@ -451,8 +450,6 @@ private:
 	bool deleting; /**< Deleting mode enabled or disabled */
 	bool segmentating; /**< Segmentating mode enabled or disabled */
 	bool showPlane; /**< Show or hide plane */
-	unsigned int sliceRuleCounter; /**< Number of slice rules */
-	unsigned int rodCounter; /**< Number of RODs */
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
### Issues solved with this PR

- [Assign rules to ROD](https://github.com/fblupi/3DCurator/issues/32): I have created a list in the UI assigning each element a rule that will be stored in a map of the ROAD. When a ROD is selected the list of rules in the UI will be the rules in that ROD, hiding the other ROD's ones

### Platform, compiler and libraries versions

- Windows 10
- Microsoft Visual Studio Compiler 2017 64 bits
- Qt5.9.1
- VTK 8.0.0
- ITK 4.12.0
- Boost 1.64
- OpenCV 3.2.0
- CMake 3.8.2