### PR TITLE
Assign protractors to ROD

### DIFF
--- a/src/3DCurator.cpp
+++ b/src/3DCurator.cpp
@@ -6,7 +6,7 @@
 
 #include "GUI/MainWindow.h"
 
-//#define RELEASE
+#define RELEASE
 
 #ifdef RELEASE
 #define WINAPI __stdcall

--- a/src/Documentation/ROD.cpp
+++ b/src/Documentation/ROD.cpp
@@ -22,6 +22,15 @@ ROD::ROD(const std::string name, const double* origin, const double* point1, con
 	this->disabled = disabled;
 }
 
+ROD::~ROD() {
+	delete origin;
+	delete point1;
+	delete point2;
+	clearAllRules();
+	clearAllProtractors();
+	clearAllAnnotations();
+}
+
 std::string ROD::getName() const {
 	return std::string();
 }
@@ -90,7 +99,7 @@ void ROD::enableDisableRule(QListWidgetItem* item) {
 }
 
 void ROD::hideAllRules() {
-	std::map<QListWidgetItem*, vtkSmartPointer<vtkDistanceWidget>>::iterator it;
+	std::map<QListWidgetItem*, vtkSmartPointer<vtkDistanceWidget> >::iterator it;
 	for (it = rules.begin(); it != rules.end(); ++it) {
 		it->first->setHidden(true);
 		it->second->Off();
@@ -98,7 +107,7 @@ void ROD::hideAllRules() {
 }
 
 void ROD::showAllRules() {
-	std::map<QListWidgetItem*, vtkSmartPointer<vtkDistanceWidget>>::iterator it;
+	std::map<QListWidgetItem*, vtkSmartPointer<vtkDistanceWidget> >::iterator it;
 	for (it = rules.begin(); it != rules.end(); ++it) {
 		it->first->setHidden(false);
 		if (it->first->font() == enabled) {
@@ -109,6 +118,56 @@ void ROD::showAllRules() {
 
 void ROD::clearAllRules() {
 	rules.clear();
+}
+
+void ROD::addProtractor(QListWidgetItem* item, vtkSmartPointer<vtkRenderWindowInteractor> interactor) {
+	protractors[item] = vtkSmartPointer<vtkAngleWidget>::New();
+	protractors[item]->SetInteractor(interactor);
+	protractors[item]->CreateDefaultRepresentation();
+	protractors[item]->On();
+}
+
+void ROD::deleteProtractor(QListWidgetItem* item) {
+	protractors.erase(item);
+}
+
+void ROD::enableProtractor(QListWidgetItem* item) {
+	item->setFont(enabled);
+	protractors[item]->On();
+}
+
+void ROD::disableProtractor(QListWidgetItem* item) {
+	item->setFont(disabled);
+	protractors[item]->Off();
+}
+
+void ROD::enableDisableProtractor(QListWidgetItem* item) {
+	if (item->font() == disabled) {
+		enableProtractor(item);
+		item->setFont(enabled);
+	}
+	else {
+		disableProtractor(item);
+		item->setFont(disabled);
+	}
+}
+
+void ROD::hideAllProtractors() {
+	std::map<QListWidgetItem*, vtkSmartPointer<vtkAngleWidget> >::iterator it;
+	for (it = protractors.begin(); it != protractors.end(); ++it) {
+		it->first->setHidden(true);
+		it->second->Off();
+	}
+}
+
+void ROD::showAllProtractors() {
+	std::map<QListWidgetItem*, vtkSmartPointer<vtkAngleWidget> >::iterator it;
+	for (it = protractors.begin(); it != protractors.end(); ++it) {
+		it->first->setHidden(false);
+		if (it->first->font() == enabled) {
+			it->second->On();
+		}
+	}
 }
 
 void ROD::clearAllProtractors() {

--- a/src/Documentation/ROD.h
+++ b/src/Documentation/ROD.h
@@ -11,6 +11,7 @@
 #include <vtkSmartPointer.h>
 #include <vtkDistanceWidget.h>
 #include <vtkDistanceRepresentation.h>
+#include <vtkAngleRepresentation2D.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkAngleWidget.h>
 
@@ -27,6 +28,11 @@ public:
 	 * @param	disabled	Font for disabled list elements
 	 */
 	ROD(const std::string name, const double* origin, const double* point1, const double* point2, const double slice, const QFont enabled, const QFont disabled);
+
+	/**
+	 * Destructor
+	 */
+	~ROD();
 
 	/**
 	 * Get ROD name
@@ -126,6 +132,46 @@ public:
 	 * Delete all rules
 	 */
 	void clearAllRules();
+
+	/**
+	 * Add new protractor to measure
+	 * @param	item	Rule item in UI
+	 */
+	void addProtractor(QListWidgetItem* item, vtkSmartPointer<vtkRenderWindowInteractor> interactor);
+
+	/**
+	 * Delete selected protractor
+	 * @param	item	Protractor item in UI
+	 */
+	void deleteProtractor(QListWidgetItem* item);
+
+	/**
+	 * Enable or disable selected protractor
+	 * @param	item	Protractor item in UI
+	 */
+	void enableDisableProtractor(QListWidgetItem* item);
+
+	/**
+	 * Enable selected protractor
+	 * @param	item	Protractor item in UI
+	 */
+	void enableProtractor(QListWidgetItem* item);
+
+	/**
+	 * Disable selected protractor
+	 * @param	item	Protractor item in UI
+	 */
+	void disableProtractor(QListWidgetItem* item);
+
+	/**
+	 * Hide all protractors
+	 */
+	void hideAllProtractors();
+
+	/**
+	 * Show all protractors
+	 */
+	void showAllProtractors();
 
 	/**
 	 * Delete all protractors

--- a/src/GUI/mainwindow.cpp
+++ b/src/GUI/mainwindow.cpp
@@ -222,7 +222,7 @@ void MainWindow::importDICOM() {
 
 		removeVolume();
 		removeMesh();
-		clearAllRules(); 
+		clearAllRODs();
 
 		slicePlane->show(false);
 		disablePlane();
@@ -558,6 +558,10 @@ void MainWindow::launchWarningNoRule() {
 	launchWarning("Seleccione una regla antes");
 }
 
+void MainWindow::launchWarningNoProtractor() {
+	launchWarning("Seleccione un transportador de ángulos antes");
+}
+
 void MainWindow::launchWarningNoActiveROD() {
 	launchWarning("Seleccione un ROD antes");
 }
@@ -603,6 +607,7 @@ void MainWindow::filter() {
 void MainWindow::unsetActiveROD() {
 	if (activeROD != NULL) {
 		activeROD->hideAllRules();
+		activeROD->hideAllProtractors();
 		ui->ruleList->setCurrentItem(NULL);
 	}
 }
@@ -612,6 +617,7 @@ void MainWindow::setActiveROD(ROD* rod) {
 	if (rod != NULL) {
 		activeROD = rod;
 		activeROD->showAllRules();
+		activeROD->showAllProtractors();
 		slicePlane->setCustomPosition(activeROD->getOrigin(), activeROD->getPoint1(), activeROD->getPoint2(), activeROD->getSlicePosition());
 		renderVolume();
 		renderSlice();
@@ -645,6 +651,11 @@ void MainWindow::deleteROD() {
 		rods.erase(ui->RODList->currentItem());
 		delete ui->RODList->currentItem();
 	}
+}
+
+void MainWindow::clearAllRODs() {
+	rods.clear();
+	ui->RODList->clear();
 }
 
 void MainWindow::addRule() {
@@ -691,8 +702,56 @@ void MainWindow::clearAllRules() {
 	if (activeROD != NULL) {
 		activeROD->clearAllRules(); // clear container
 	}
-	// clear GUI lists
-	ui->ruleList->clear();
+	ui->ruleList->clear(); // clear GUI lists
+}
+
+void MainWindow::addProtractor() {
+	if (activeROD != NULL) {
+		std::string name;
+		QListWidgetItem *item = new QListWidgetItem(0);
+		bool ok;
+		QString text = QInputDialog::getText(this, tr("Nombre de la regla"), tr("Nombre:"), QLineEdit::Normal, tr("Sin nombre"), &ok);
+		if (ok) {
+			if (text.isEmpty()) {
+				name = "Sin nombre";
+			}
+			else {
+				name = text.toUtf8().constData();
+			}
+			item->setText(name.c_str());
+			ui->protractorList->addItem(item);
+			ui->protractorList->setCurrentItem(item);
+			activeROD->addProtractor(item, ui->slicesWidget->GetInteractor());
+		}
+	}
+	else {
+		launchWarningNoActiveROD();
+	}
+}
+
+void MainWindow::deleteProtractor() {
+	if (ui->protractorList->currentItem() != NULL) {
+		activeROD->deleteProtractor(ui->protractorList->currentItem());
+		delete ui->protractorList->currentItem();
+		renderSlice();
+	} else {
+		launchWarningNoProtractor();
+	}
+}
+
+void MainWindow::enableDisableProtractor() {
+	if (ui->protractorList->currentItem() != NULL) {
+		activeROD->enableDisableProtractor(ui->protractorList->currentItem());
+	} else {
+		launchWarningNoProtractor();
+	}
+}
+
+void MainWindow::clearAllProtractors() {
+	if (activeROD != NULL) {
+		activeROD->clearAllProtractors(); // clear container
+	}
+	ui->protractorList->clear(); // clear GUI lists
 }
 
 //---------------------------------------------------------------------------------------------------------------------------------
@@ -908,6 +967,18 @@ void MainWindow::on_deleteRule_pressed() {
 
 void MainWindow::on_enableDisableRule_pressed() {
 	enableDisableRule();
+}
+
+void MainWindow::on_addProtractor_pressed() {
+	addProtractor();
+}
+
+void MainWindow::on_deleteProtractor_pressed() {
+	deleteProtractor();
+}
+
+void MainWindow::on_enableDisableProtractor_pressed() {
+	enableDisableProtractor();
 }
 
 void MainWindow::on_addROD_pressed() {

--- a/src/GUI/mainwindow.h
+++ b/src/GUI/mainwindow.h
@@ -119,11 +119,14 @@ private slots:
 	void on_restoreBackgrounds_pressed();
 	void on_segmentate_pressed();
 	void on_filter_pressed();
+	void on_addROD_pressed();
+	void on_deleteROD_pressed();
 	void on_addRule_pressed();
 	void on_deleteRule_pressed();
 	void on_enableDisableRule_pressed();
-	void on_addROD_pressed();
-	void on_deleteROD_pressed();
+	void on_addProtractor_pressed();
+	void on_deleteProtractor_pressed();
+	void on_enableDisableProtractor_pressed();
 
 	void on_RODList_currentItemChanged();
 
@@ -357,6 +360,11 @@ private slots:
 	void launchWarningNoRule();
 
 	/**
+	 * Launch a warning message saying there is no protractor selected
+	 */
+	void launchWarningNoProtractor();
+
+	/**
 	 * Launch a warning message saying there is no ROD selected
 	 */
 	void launchWarningNoActiveROD();
@@ -399,6 +407,11 @@ private slots:
 	void deleteROD();
 
 	/**
+	 * Delete all RODs
+	 */
+	void clearAllRODs();
+
+	/**
 	 * Add new rule to measure
 	 */
 	void addRule();
@@ -417,6 +430,26 @@ private slots:
 	 * Delete all rules
 	 */
 	void clearAllRules();
+
+	/**
+	 * Add new protractor to measure
+	 */
+	void addProtractor();
+
+	/**
+	 * Delete selected protractor
+	 */
+	void deleteProtractor();
+
+	/**
+	 * Enable or disable selected protractor
+	 */
+	void enableDisableProtractor();
+
+	/**
+	 * Delete all protractors
+	 */
+	void clearAllProtractors();
 
 private:
 	Ui::MainWindow *ui; /**< UI pointer */

--- a/src/GUI/mainwindow.ui
+++ b/src/GUI/mainwindow.ui
@@ -587,7 +587,7 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>131</width>
+             <width>452</width>
              <height>693</height>
             </rect>
            </property>
@@ -1320,13 +1320,6 @@
          </property>
         </spacer>
        </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="angleLabel">
-         <property name="text">
-          <string>Angle</string>
-         </property>
-        </widget>
-       </item>
        <item row="1" column="0" colspan="4">
         <widget class="QListWidget" name="RODList"/>
        </item>
@@ -1553,7 +1546,7 @@
         </spacer>
        </item>
        <item row="10" column="3">
-        <widget class="QPushButton" name="addAngle">
+        <widget class="QPushButton" name="addProtractor">
          <property name="toolTip">
           <string>Añadir regla</string>
          </property>
@@ -1573,10 +1566,10 @@
         </widget>
        </item>
        <item row="9" column="0" colspan="4">
-        <widget class="QListWidget" name="angleList"/>
+        <widget class="QListWidget" name="protractorList"/>
        </item>
        <item row="10" column="0">
-        <widget class="QPushButton" name="enableDisableAngle">
+        <widget class="QPushButton" name="enableDisableProtractor">
          <property name="toolTip">
           <string>Mostrar/Esconder regla</string>
          </property>
@@ -1596,7 +1589,7 @@
         </widget>
        </item>
        <item row="10" column="2">
-        <widget class="QPushButton" name="deleteAngle">
+        <widget class="QPushButton" name="deleteProtractor">
          <property name="toolTip">
           <string>Eliminar regla</string>
          </property>
@@ -1633,6 +1626,13 @@
        </item>
        <item row="13" column="0" colspan="4">
         <widget class="QTextEdit" name="annotation"/>
+       </item>
+       <item row="8" column="0" colspan="4">
+        <widget class="QLabel" name="protractorLabel">
+         <property name="text">
+          <string>Transportadores de ángulos</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
### Issues solved with this PR

- [Assign protractors to ROD](https://github.com/fblupi/3DCurator/issues/38):  have created a list in the UI assigning each element a protractor that will be stored in a map of the ROD. When a ROD is selected the list of protractors in the UI will be the protractors in that ROD, hiding the other ROD's ones

### Platform, compiler and libraries versions

- Windows 10
- Microsoft Visual Studio Compiler 2017 64 bits
- Qt5.9.1
- VTK 8.0.0
- ITK 4.12.0
- Boost 1.64
- OpenCV 3.2.0
- CMake 3.8.2
