### PR TITLE
Annotations and plane&ROD bug

### DIFF
--- a/src/Documentation/ROD.cpp
+++ b/src/Documentation/ROD.cpp
@@ -31,10 +31,6 @@ ROD::~ROD() {
 	clearAllAnnotations();
 }
 
-std::string ROD::getName() const {
-	return std::string();
-}
-
 double* ROD::getOrigin() const {
 	return origin;
 }
@@ -49,21 +45,6 @@ double* ROD::getPoint2() const {
 
 double ROD::getSlicePosition() const {
 	return slice;
-}
-std::map<QListWidgetItem*, vtkSmartPointer<vtkDistanceWidget> > ROD::getRules() const {
-	return rules;
-}
-
-std::map<QListWidgetItem*, vtkSmartPointer<vtkAngleWidget> > ROD::getProtractors() const {
-	return protractors;
-}
-
-std::map<double*, std::string> ROD::getAnnotations() const {
-	return annotations;
-}
-
-void ROD::setName(const std::string name) {
-	this->name = name;
 }
 
 void ROD::addRule(QListWidgetItem* item, vtkSmartPointer<vtkRenderWindowInteractor> interactor) {
@@ -174,6 +155,60 @@ void ROD::clearAllProtractors() {
 	protractors.clear();
 }
 
+void ROD::addAnnotation(QListWidgetItem* item, std::string text, vtkSmartPointer<vtkRenderWindowInteractor> interactor) {
+	vtkSmartPointer<vtkCaptionRepresentation> captionRepresentation = vtkSmartPointer<vtkCaptionRepresentation>::New();
+	captionRepresentation->GetCaptionActor2D()->SetCaption(text.c_str());
+	captionRepresentation->GetCaptionActor2D()->BorderOff();
+	captionRepresentation->GetCaptionActor2D()->GetTextActor()->SetMinimumSize(300, 300);
+	annotations[item] = vtkSmartPointer<vtkCaptionWidget>::New();
+	annotations[item]->SetInteractor(interactor);
+	annotations[item]->CreateDefaultRepresentation();
+	annotations[item]->SetRepresentation(captionRepresentation);
+	annotations[item]->On();
+}
+
+void ROD::deleteAnnotation(QListWidgetItem* item) {
+	annotations.erase(item);
+}
+
+void ROD::enableAnnotation(QListWidgetItem* item) {
+	item->setFont(enabled);
+	annotations[item]->On();
+}
+
+void ROD::disableAnnotation(QListWidgetItem* item) {
+	item->setFont(disabled);
+	annotations[item]->Off();
+}
+
+void ROD::enableDisableAnnotation(QListWidgetItem* item) {
+	if (item->font() == disabled) {
+		enableAnnotation(item);
+		item->setFont(enabled);
+	} else {
+		disableAnnotation(item);
+		item->setFont(disabled);
+	}
+}
+
+void ROD::hideAllAnnotations() {
+	std::map<QListWidgetItem*, vtkSmartPointer<vtkCaptionWidget> >::iterator it;
+	for (it = annotations.begin(); it != annotations.end(); ++it) {
+		it->first->setHidden(true);
+		it->second->Off();
+	}
+}
+
+void ROD::showAllAnnotations() {
+	std::map<QListWidgetItem*, vtkSmartPointer<vtkCaptionWidget> >::iterator it;
+	for (it = annotations.begin(); it != annotations.end(); ++it) {
+		it->first->setHidden(false);
+		if (it->first->font() == enabled) {
+			it->second->On();
+		}
+	}
+}
+
 void ROD::clearAllAnnotations() {
 	annotations.clear();
 }
@@ -181,4 +216,11 @@ void ROD::clearAllAnnotations() {
 void ROD::hideAll() {
 	hideAllRules();
 	hideAllProtractors();
+	hideAllAnnotations();
+}
+
+void ROD::showAll() {
+	showAllRules();
+	showAllProtractors();
+	showAllAnnotations();
 }

--- a/src/Documentation/ROD.cpp
+++ b/src/Documentation/ROD.cpp
@@ -224,3 +224,18 @@ void ROD::showAll() {
 	showAllProtractors();
 	showAllAnnotations();
 }
+
+bool ROD::samePlane(const double* origin, const double* point1, const double* point2, const double slice) {
+	return (
+		this->origin[0] == origin[0] &&
+		this->origin[1] == origin[1] &&
+		this->origin[2] == origin[2] &&
+		this->point1[0] == point1[0] &&
+		this->point1[1] == point1[1] &&
+		this->point1[2] == point1[2] &&
+		this->point2[0] == point2[0] &&
+		this->point2[1] == point2[1] &&
+		this->point2[2] == point2[2] &&
+		this->slice == slice
+	);
+}

--- a/src/Documentation/ROD.h
+++ b/src/Documentation/ROD.h
@@ -212,6 +212,16 @@ public:
 	 */
 	void showAll();
 
+	/**
+	 * Compare if the input plane is the same as the ROD's one
+	 * @param	origin		Origin of the plane
+	 * @param	point1		Position of the point defining the first axis of the plane
+	 * @param	point2		Position of the point defining the second axis of the plane
+	 * @param	slice		Slice position in terms of data extent
+	 * @return	The input plane is the same as the ROD's one
+	 */
+	bool samePlane(const double* origin, const double* point1, const double* point2, const double slice);
+
 private:
 	std::string name; /**< ROD name */
 	double* origin; /**< Origin of the plane */

--- a/src/Documentation/ROD.h
+++ b/src/Documentation/ROD.h
@@ -9,11 +9,16 @@
 #include <vector>
 
 #include <vtkSmartPointer.h>
+#include <vtkRenderWindowInteractor.h>
 #include <vtkDistanceWidget.h>
 #include <vtkDistanceRepresentation.h>
-#include <vtkAngleRepresentation2D.h>
-#include <vtkRenderWindowInteractor.h>
 #include <vtkAngleWidget.h>
+#include <vtkAngleRepresentation2D.h>
+#include <vtkCaptionWidget.h>
+#include <vtkCaptionRepresentation.h>
+#include <vtkCaptionActor2D.h>
+#include <vtkTextActor.h>
+#include <vtkTextProperty.h>
 
 class ROD {
 public:
@@ -33,12 +38,6 @@ public:
 	 * Destructor
 	 */
 	~ROD();
-
-	/**
-	 * Get ROD name
-	 * @return	ROD name
-	 */
-	std::string getName() const;
 
 	/**
 	 * Get origin of the plane
@@ -65,32 +64,9 @@ public:
 	double getSlicePosition() const;
 
 	/**
-	 * Get ROD rules
-	 * @return	ROD rules
-	 */
-	std::map<QListWidgetItem*, vtkSmartPointer<vtkDistanceWidget> > getRules() const;
-
-	/**
-	 * Get ROD protractors
-	 * @return	ROD protractors
-	 */
-	std::map<QListWidgetItem*, vtkSmartPointer<vtkAngleWidget> > getProtractors() const;
-
-	/**
-	 * Get ROD annotations
-	 * @return	ROD annotations
-	 */
-	std::map<double*, std::string> getAnnotations() const;
-
-	/**
-	 * Set ROD name
-	 * @param	name	ROD name
-	 */
-	void setName(const std::string name);
-
-	/**
 	 * Add new rule to measure
-	 * @param	item	Rule item in UI
+	 * @param	item		Rule item in UI
+	 * @param	interactor	Render window interactor where will be placed
 	 */
 	void addRule(QListWidgetItem* item, vtkSmartPointer<vtkRenderWindowInteractor> interactor);
 
@@ -135,7 +111,8 @@ public:
 
 	/**
 	 * Add new protractor to measure
-	 * @param	item	Rule item in UI
+	 * @param	item		Rule item in UI
+	 * @param	interactor	Render window interactor where will be placed
 	 */
 	void addProtractor(QListWidgetItem* item, vtkSmartPointer<vtkRenderWindowInteractor> interactor);
 
@@ -179,6 +156,48 @@ public:
 	void clearAllProtractors();
 
 	/**
+	 * Add new annotation
+	 * @param	item		Rule item in UI
+	 * @param	text		Annotation text
+	 * @param	interactor	Render window interactor where will be placed
+	 */
+	void addAnnotation(QListWidgetItem* item, std::string text, vtkSmartPointer<vtkRenderWindowInteractor> interactor);
+
+	/**
+	* Delete selected annotation
+	* @param	item	Annotation item in UI
+	*/
+	void deleteAnnotation(QListWidgetItem* item);
+
+	/**
+	* Enable or disable selected annotation
+	* @param	item	Annotation item in UI
+	*/
+	void enableDisableAnnotation(QListWidgetItem* item);
+
+	/**
+	* Enable selected annotation
+	* @param	item	Protractor item in UI
+	*/
+	void enableAnnotation(QListWidgetItem* item);
+
+	/**
+	* Disable selected annotation
+	* @param	item	Annotation item in UI
+	*/
+	void disableAnnotation(QListWidgetItem* item);
+
+	/**
+	* Hide all annotations
+	*/
+	void hideAllAnnotations();
+
+	/**
+	* Show all annotations
+	*/
+	void showAllAnnotations();
+
+	/**
 	 * Delete all annotations
 	 */
 	void clearAllAnnotations();
@@ -188,6 +207,11 @@ public:
 	 */
 	void hideAll();
 
+	/**
+	 * Show all ROD elements
+	 */
+	void showAll();
+
 private:
 	std::string name; /**< ROD name */
 	double* origin; /**< Origin of the plane */
@@ -196,7 +220,7 @@ private:
 	double slice; /**< Slice position in terms of data extent */
 	std::map<QListWidgetItem*, vtkSmartPointer<vtkDistanceWidget> > rules; /**< Rules container */
 	std::map<QListWidgetItem*, vtkSmartPointer<vtkAngleWidget> > protractors; /**< Rules container */
-	std::map<double*, std::string> annotations; /**< Annotations container */
+	std::map<QListWidgetItem*, vtkSmartPointer<vtkCaptionWidget> > annotations; /**< Annotations container */
 
 	QFont enabled; /**< Font for list enabled elements */
 	QFont disabled; /**< Font for list disabled elements */

--- a/src/GUI/mainwindow.cpp
+++ b/src/GUI/mainwindow.cpp
@@ -564,6 +564,14 @@ void MainWindow::launchWarningNoProtractor() {
 	launchWarning("Seleccione un transportador de ángulos antes");
 }
 
+void MainWindow::launchWarningNoAnnotationText() {
+	launchWarning("Escribe el texto de la nota antes");
+}
+
+void MainWindow::launchWarningNoAnnotation() {
+	launchWarning("Seleccione una nota antes");
+}
+
 void MainWindow::launchWarningNoActiveROD() {
 	launchWarning("Seleccione un ROD antes");
 }
@@ -609,7 +617,7 @@ void MainWindow::filter() {
 void MainWindow::unsetActiveROD() {
 	if (activeROD != NULL) {
 		activeROD->hideAll();
-		ui->ruleList->setCurrentItem(nullROD);
+		ui->RODList->setCurrentItem(nullROD);
 		updateActiveROD(NULL);
 		nullROD->setSelected(true);
 	}
@@ -619,8 +627,7 @@ void MainWindow::setActiveROD(ROD* rod) {
 	unsetActiveROD();
 	if (rod != NULL) {
 		updateActiveROD(rod);
-		activeROD->showAllRules();
-		activeROD->showAllProtractors();
+		activeROD->showAll();
 		slicePlane->setCustomPosition(activeROD->getOrigin(), activeROD->getPoint1(), activeROD->getPoint2(), activeROD->getSlicePosition());
 		renderVolume();
 		renderSlice();
@@ -710,24 +717,16 @@ void MainWindow::enableDisableRule() {
 	}
 }
 
-void MainWindow::clearAllRules() {
-	if (activeROD != NULL) {
-		activeROD->clearAllRules(); // clear container
-	}
-	ui->ruleList->clear(); // clear GUI lists
-}
-
 void MainWindow::addProtractor() {
 	if (activeROD != NULL) {
 		std::string name;
 		QListWidgetItem *item = new QListWidgetItem(0);
 		bool ok;
-		QString text = QInputDialog::getText(this, tr("Nombre de la regla"), tr("Nombre:"), QLineEdit::Normal, tr("Sin nombre"), &ok);
+		QString text = QInputDialog::getText(this, tr("Nombre del transportador de ángulos"), tr("Nombre:"), QLineEdit::Normal, tr("Sin nombre"), &ok);
 		if (ok) {
 			if (text.isEmpty()) {
 				name = "Sin nombre";
-			}
-			else {
+			} else {
 				name = text.toUtf8().constData();
 			}
 			item->setText(name.c_str());
@@ -758,11 +757,50 @@ void MainWindow::enableDisableProtractor() {
 	}
 }
 
-void MainWindow::clearAllProtractors() {
+void MainWindow::addAnnotation() {
 	if (activeROD != NULL) {
-		activeROD->clearAllProtractors(); // clear container
+		std::string name;
+		std::string description = ui->annotation->toPlainText().toUtf8().constData();
+		if (description == "") {
+			launchWarningNoAnnotationText();
+		} else {
+			QListWidgetItem *item = new QListWidgetItem(0);
+			bool ok;
+			QString text = QInputDialog::getText(this, tr("Nombre de la nota"), tr("Nombre:"), QLineEdit::Normal, tr("Sin nombre"), &ok);
+			if (ok) {
+				if (text.isEmpty()) {
+					name = "Sin nombre";
+				} else {
+					name = text.toUtf8().constData();
+				}
+				item->setText(name.c_str());
+				ui->annotationList->addItem(item);
+				ui->annotationList->setCurrentItem(item);
+				activeROD->addAnnotation(item, description, ui->slicesWidget->GetInteractor());
+				ui->annotation->clear();
+			}
+		}
+	} else {
+		launchWarningNoActiveROD();
 	}
-	ui->protractorList->clear(); // clear GUI lists
+}
+
+void MainWindow::deleteAnnotation() {
+	if (ui->annotationList->currentItem() != NULL) {
+		activeROD->deleteAnnotation(ui->annotationList->currentItem());
+		delete ui->annotationList->currentItem();
+		renderSlice();
+	} else {
+		launchWarningNoAnnotation();
+	}
+}
+
+void MainWindow::enableDisableAnnotation() {
+	if (ui->annotationList->currentItem() != NULL) {
+		activeROD->enableDisableAnnotation(ui->annotationList->currentItem());
+	} else {
+		launchWarningNoAnnotation();
+	}
 }
 
 //---------------------------------------------------------------------------------------------------------------------------------
@@ -992,12 +1030,24 @@ void MainWindow::on_enableDisableProtractor_pressed() {
 	enableDisableProtractor();
 }
 
+void MainWindow::on_addAnnotation_pressed() {
+	addAnnotation();
+}
+
+void MainWindow::on_deleteAnnotation_pressed() {
+	deleteAnnotation();
+}
+
 void MainWindow::on_addROD_pressed() {
 	addROD();
 }
 
 void MainWindow::on_deleteROD_pressed() {
 	deleteROD();
+}
+
+void MainWindow::on_enableDisableAnnotation_pressed() {
+	enableDisableAnnotation();
 }
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/src/GUI/mainwindow.cpp
+++ b/src/GUI/mainwindow.cpp
@@ -624,7 +624,9 @@ void MainWindow::unsetActiveROD() {
 }
 
 void MainWindow::setActiveROD(ROD* rod) {
-	unsetActiveROD();
+	if (activeROD != NULL) {
+		activeROD->hideAll();
+	}
 	if (rod != NULL) {
 		updateActiveROD(rod);
 		activeROD->showAll();
@@ -666,6 +668,7 @@ void MainWindow::deleteROD() {
 	if (activeROD != NULL) {
 		rods.erase(ui->RODList->currentItem());
 		delete ui->RODList->currentItem();
+		unsetActiveROD();
 	}
 }
 
@@ -678,6 +681,9 @@ void MainWindow::clearAllRODs() {
 }
 
 void MainWindow::addRule() {
+	if (activeROD != NULL && !activeROD->samePlane(slicePlane->getOrigin(), slicePlane->getPoint1(), slicePlane->getPoint2(), slicePlane->getSlicePosition())) {
+		unsetActiveROD();
+	}
 	if (activeROD != NULL) {
 		std::string name;
 		QListWidgetItem *item = new QListWidgetItem(0);
@@ -718,6 +724,9 @@ void MainWindow::enableDisableRule() {
 }
 
 void MainWindow::addProtractor() {
+	if (activeROD != NULL && !activeROD->samePlane(slicePlane->getOrigin(), slicePlane->getPoint1(), slicePlane->getPoint2(), slicePlane->getSlicePosition())) {
+		unsetActiveROD();
+	}
 	if (activeROD != NULL) {
 		std::string name;
 		QListWidgetItem *item = new QListWidgetItem(0);
@@ -758,6 +767,9 @@ void MainWindow::enableDisableProtractor() {
 }
 
 void MainWindow::addAnnotation() {
+	if (activeROD != NULL && !activeROD->samePlane(slicePlane->getOrigin(), slicePlane->getPoint1(), slicePlane->getPoint2(), slicePlane->getSlicePosition())) {
+		unsetActiveROD();
+	}
 	if (activeROD != NULL) {
 		std::string name;
 		std::string description = ui->annotation->toPlainText().toUtf8().constData();

--- a/src/GUI/mainwindow.h
+++ b/src/GUI/mainwindow.h
@@ -127,6 +127,9 @@ private slots:
 	void on_addProtractor_pressed();
 	void on_deleteProtractor_pressed();
 	void on_enableDisableProtractor_pressed();
+	void on_addAnnotation_pressed();
+	void on_deleteAnnotation_pressed();
+	void on_enableDisableAnnotation_pressed();
 
 	void on_RODList_currentItemChanged();
 
@@ -365,6 +368,16 @@ private slots:
 	void launchWarningNoProtractor();
 
 	/**
+	 * Launch a warning message saying there is no annotation text written
+	 */
+	void launchWarningNoAnnotationText();
+
+	/**
+	 * Launch a warning message saying there is no annotation selected
+	 */
+	void launchWarningNoAnnotation();
+
+	/**
 	 * Launch a warning message saying there is no ROD selected
 	 */
 	void launchWarningNoActiveROD();
@@ -433,11 +446,6 @@ private slots:
 	void enableDisableRule();
 
 	/**
-	 * Delete all rules
-	 */
-	void clearAllRules();
-
-	/**
 	 * Add new protractor to measure
 	 */
 	void addProtractor();
@@ -453,9 +461,19 @@ private slots:
 	void enableDisableProtractor();
 
 	/**
-	 * Delete all protractors
+	 * Add new annotation to measure
 	 */
-	void clearAllProtractors();
+	void addAnnotation();
+
+	/**
+	 * Delete annotation
+	 */
+	void deleteAnnotation();
+
+	/**
+	 * Enable or disable selected annotation
+	 */
+	void enableDisableAnnotation();
 
 private:
 	Ui::MainWindow *ui; /**< UI pointer */

--- a/src/GUI/mainwindow.ui
+++ b/src/GUI/mainwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1143</width>
-    <height>696</height>
+    <width>1024</width>
+    <height>768</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,16 +19,6 @@
   </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QGridLayout" name="gridLayout">
-    <item row="1" column="0">
-     <widget class="QVTKWidget" name="volumeWidget">
-      <property name="minimumSize">
-       <size>
-        <width>400</width>
-        <height>400</height>
-       </size>
-      </property>
-     </widget>
-    </item>
     <item row="0" column="0">
      <widget class="QGroupBox" name="groupBox">
       <property name="maximumSize">
@@ -149,7 +139,7 @@
        <attribute name="title">
         <string>Cortes</string>
        </attribute>
-       <layout class="QGridLayout" name="gridLayout_5">
+       <layout class="QGridLayout" name="gridLayout_3">
         <item row="0" column="0" colspan="3">
          <widget class="QGroupBox" name="planeOptions">
           <property name="minimumSize">
@@ -587,7 +577,7 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>131</width>
+             <width>391</width>
              <height>693</height>
             </rect>
            </property>
@@ -1276,19 +1266,6 @@
       </widget>
      </widget>
     </item>
-    <item row="2" column="0">
-     <widget class="QLabel" name="labelFolder">
-      <property name="maximumSize">
-       <size>
-        <width>16777215</width>
-        <height>13</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Carpeta</string>
-      </property>
-     </widget>
-    </item>
     <item row="0" column="2" rowspan="3">
      <widget class="QGroupBox" name="documentationBox">
       <property name="minimumSize">
@@ -1306,8 +1283,58 @@
       <property name="title">
        <string>Documentación</string>
       </property>
-      <layout class="QGridLayout" name="gridLayout_3">
-       <item row="2" column="0" colspan="2">
+      <layout class="QGridLayout" name="gridLayout_5">
+       <item row="0" column="0" colspan="3">
+        <spacer name="horizontalSpacer_21">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>59</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="3">
+        <widget class="QPushButton" name="importROD">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../assets/resources.qrc">
+           <normaloff>:/icons/folder.png</normaloff>:/icons/folder.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>21</width>
+           <height>21</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="5">
+        <widget class="QPushButton" name="exportROD">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../assets/resources.qrc">
+           <normaloff>:/icons/save.png</normaloff>:/icons/save.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>21</width>
+           <height>21</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="6">
+        <widget class="QListWidget" name="RODList"/>
+       </item>
+       <item row="2" column="0" colspan="3">
         <spacer name="horizontalSpacer_22">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -1320,10 +1347,7 @@
          </property>
         </spacer>
        </item>
-       <item row="1" column="0" colspan="4">
-        <widget class="QListWidget" name="RODList"/>
-       </item>
-       <item row="2" column="2">
+       <item row="2" column="3" colspan="2">
         <widget class="QPushButton" name="deleteROD">
          <property name="toolTip">
           <string>Eliminar regla</string>
@@ -1343,64 +1367,8 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="0" colspan="2">
-        <spacer name="horizontalSpacer_21">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>59</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="ruleLabel">
-         <property name="text">
-          <string>Reglas</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QPushButton" name="enableDisableRule">
-         <property name="toolTip">
-          <string>Mostrar/Esconder regla</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../assets/resources.qrc">
-           <normaloff>:/icons/eye.png</normaloff>:/icons/eye.png</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>21</width>
-           <height>21</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0" colspan="4">
-        <widget class="QListWidget" name="ruleList"/>
-       </item>
-       <item row="6" column="1">
-        <spacer name="horizontalSpacer_11">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="6" column="3">
-        <widget class="QPushButton" name="addRule">
+       <item row="2" column="5">
+        <widget class="QPushButton" name="addROD">
          <property name="toolTip">
           <string>Añadir regla</string>
          </property>
@@ -1410,23 +1378,6 @@
          <property name="icon">
           <iconset resource="../../assets/resources.qrc">
            <normaloff>:/icons/plus.png</normaloff>:/icons/plus.png</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>21</width>
-           <height>21</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QPushButton" name="importROD">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../assets/resources.qrc">
-           <normaloff>:/icons/folder.png</normaloff>:/icons/folder.png</iconset>
          </property>
          <property name="iconSize">
           <size>
@@ -1452,14 +1403,27 @@
          </property>
         </spacer>
        </item>
-       <item row="0" column="3">
-        <widget class="QPushButton" name="exportROD">
+       <item row="4" column="0" colspan="2">
+        <widget class="QLabel" name="ruleLabel">
+         <property name="text">
+          <string>Reglas</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="6">
+        <widget class="QListWidget" name="ruleList"/>
+       </item>
+       <item row="6" column="0">
+        <widget class="QPushButton" name="enableDisableRule">
+         <property name="toolTip">
+          <string>Mostrar/Esconder regla</string>
+         </property>
          <property name="text">
           <string/>
          </property>
          <property name="icon">
           <iconset resource="../../assets/resources.qrc">
-           <normaloff>:/icons/save.png</normaloff>:/icons/save.png</iconset>
+           <normaloff>:/icons/eye.png</normaloff>:/icons/eye.png</iconset>
          </property>
          <property name="iconSize">
           <size>
@@ -1470,6 +1434,19 @@
         </widget>
        </item>
        <item row="6" column="2">
+        <spacer name="horizontalSpacer_11">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="6" column="3">
         <widget class="QPushButton" name="deleteRule">
          <property name="toolTip">
           <string>Eliminar regla</string>
@@ -1480,6 +1457,26 @@
          <property name="icon">
           <iconset resource="../../assets/resources.qrc">
            <normaloff>:/icons/minus.png</normaloff>:/icons/minus.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>21</width>
+           <height>21</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="5">
+        <widget class="QPushButton" name="addRule">
+         <property name="toolTip">
+          <string>Añadir regla</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../assets/resources.qrc">
+           <normaloff>:/icons/plus.png</normaloff>:/icons/plus.png</iconset>
          </property>
          <property name="iconSize">
           <size>
@@ -1505,67 +1502,14 @@
          </property>
         </spacer>
        </item>
-       <item row="2" column="3">
-        <widget class="QPushButton" name="addROD">
-         <property name="toolTip">
-          <string>Añadir regla</string>
-         </property>
+       <item row="8" column="0" colspan="6">
+        <widget class="QLabel" name="protractorLabel">
          <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../assets/resources.qrc">
-           <normaloff>:/icons/plus.png</normaloff>:/icons/plus.png</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>21</width>
-           <height>21</height>
-          </size>
+          <string>Transportadores de ángulos</string>
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
-        <widget class="QLabel" name="annotationLabel">
-         <property name="text">
-          <string>Nota</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="1">
-        <spacer name="horizontalSpacer_12">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="10" column="3">
-        <widget class="QPushButton" name="addProtractor">
-         <property name="toolTip">
-          <string>Añadir regla</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../assets/resources.qrc">
-           <normaloff>:/icons/plus.png</normaloff>:/icons/plus.png</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>21</width>
-           <height>21</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0" colspan="4">
+       <item row="9" column="0" colspan="6">
         <widget class="QListWidget" name="protractorList"/>
        </item>
        <item row="10" column="0">
@@ -1589,6 +1533,19 @@
         </widget>
        </item>
        <item row="10" column="2">
+        <spacer name="horizontalSpacer_12">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="10" column="3">
         <widget class="QPushButton" name="deleteProtractor">
          <property name="toolTip">
           <string>Eliminar regla</string>
@@ -1599,6 +1556,26 @@
          <property name="icon">
           <iconset resource="../../assets/resources.qrc">
            <normaloff>:/icons/minus.png</normaloff>:/icons/minus.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>21</width>
+           <height>21</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="5">
+        <widget class="QPushButton" name="addProtractor">
+         <property name="toolTip">
+          <string>Añadir regla</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../assets/resources.qrc">
+           <normaloff>:/icons/plus.png</normaloff>:/icons/plus.png</iconset>
          </property>
          <property name="iconSize">
           <size>
@@ -1624,17 +1601,127 @@
          </property>
         </spacer>
        </item>
-       <item row="13" column="0" colspan="4">
-        <widget class="QTextEdit" name="annotation"/>
-       </item>
-       <item row="8" column="0" colspan="4">
-        <widget class="QLabel" name="protractorLabel">
+       <item row="12" column="0">
+        <widget class="QLabel" name="annotationLabel">
          <property name="text">
-          <string>Transportadores de ángulos</string>
+          <string>Nota</string>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="0" colspan="6">
+        <widget class="QTextEdit" name="annotation">
+         <property name="html">
+          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="placeholderText">
+          <string>Introducir aquí el texto de la nota antes de crearla</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="0" colspan="6">
+        <widget class="QListWidget" name="annotationList"/>
+       </item>
+       <item row="15" column="0">
+        <widget class="QPushButton" name="enableDisableAnnotation">
+         <property name="toolTip">
+          <string>Mostrar/Esconder regla</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../assets/resources.qrc">
+           <normaloff>:/icons/eye.png</normaloff>:/icons/eye.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>21</width>
+           <height>21</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="1" colspan="2">
+        <spacer name="horizontalSpacer_23">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>26</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="15" column="3">
+        <widget class="QPushButton" name="deleteAnnotation">
+         <property name="toolTip">
+          <string>Eliminar regla</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../assets/resources.qrc">
+           <normaloff>:/icons/minus.png</normaloff>:/icons/minus.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>21</width>
+           <height>21</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="4" colspan="2">
+        <widget class="QPushButton" name="addAnnotation">
+         <property name="toolTip">
+          <string>Añadir regla</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../assets/resources.qrc">
+           <normaloff>:/icons/plus.png</normaloff>:/icons/plus.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>21</width>
+           <height>21</height>
+          </size>
          </property>
         </widget>
        </item>
       </layout>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QVTKWidget" name="volumeWidget">
+      <property name="minimumSize">
+       <size>
+        <width>400</width>
+        <height>400</height>
+       </size>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="labelFolder">
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>13</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Carpeta</string>
+      </property>
      </widget>
     </item>
    </layout>
@@ -1644,7 +1731,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1143</width>
+     <width>1024</width>
      <height>21</height>
     </rect>
    </property>

--- a/src/Widget/imagePlaneWidget.cpp
+++ b/src/Widget/imagePlaneWidget.cpp
@@ -23,9 +23,7 @@ void ImagePlaneWidget::OnRightButtonUp() {
 void ImagePlaneWidget::unsetActiveROD() {
 	if (activeROD != NULL && listROD != NULL) {
 		activeROD->hideAll();
-		listROD->setCurrentItem(nullROD);
-		activeROD = NULL;
-		nullROD->setSelected(true);
+		listROD->setCurrentItem(NULL);
 	}
 }
 


### PR DESCRIPTION
### Issues solved with this PR

- [Add annotations to ROD](https://github.com/fblupi/3DCurator/issues/33): Same method that as the one used with rules and protractors, but adding firstly the annotation text in a text area
- [Change item in list when moving the plane](https://github.com/fblupi/3DCurator/issues/50):  Check if the current slice plane is the same than the ROD's one


### Platform, compiler and libraries versions

- Windows 10
- Microsoft Visual Studio Compiler 2017 64 bits
- Qt5.9.1
- VTK 8.0.0
- ITK 4.12.0
- Boost 1.64
- OpenCV 3.2.0
- CMake 3.8.2
