### PR TITLE
Unset ROD when changing the plane with the plane position buttons

### DIFF
--- a/src/GUI/mainwindow.cpp
+++ b/src/GUI/mainwindow.cpp
@@ -253,7 +253,7 @@ void MainWindow::importVTI() {
 		QPointer<QProgressBar> bar = new QProgressBar(0);
 		QPointer<QProgressDialog> progressDialog = new QProgressDialog(0);
 		progressDialog->setWindowTitle(QString("Cargando..."));
-		progressDialog->setLabelText(QString::fromLatin1("Cargando los datos DICOM especificados"));
+		progressDialog->setLabelText(QString::fromLatin1("Cargando los datos especificados"));
 		progressDialog->setWindowIcon(QIcon(":/icons/3DCurator.png"));
 		progressDialog->setWindowFlags(progressDialog->windowFlags() & ~Qt::WindowCloseButtonHint);
 		progressDialog->setCancelButton(0);
@@ -509,6 +509,9 @@ void MainWindow::enableDisablePlane() {
 void MainWindow::axialPlane() {
 	if (sculpture->getLoaded()) {
 		slicePlane->setAxial();
+		if (activeROD != NULL) {
+			unsetActiveROD();
+		}
 		renderVolume();
 		renderSlice();
 	} else {
@@ -519,6 +522,9 @@ void MainWindow::axialPlane() {
 void MainWindow::coronalPlane() {
 	if (sculpture->getLoaded()) {
 		slicePlane->setCoronal();
+		if (activeROD != NULL) {
+			unsetActiveROD();
+		}
 		renderVolume();
 		renderSlice();
 	} else {
@@ -529,6 +535,9 @@ void MainWindow::coronalPlane() {
 void MainWindow::sagitalPlane() {
 	if (sculpture->getLoaded()) {
 		slicePlane->setSagital();
+		if (activeROD != NULL) {
+			unsetActiveROD();
+		}
 		renderVolume();
 		renderSlice();
 	} else {


### PR DESCRIPTION
### Issues solved with this PR

- [Unset active ROD when changing the plane with the plane position buttons](https://github.com/fblupi/3DCurator/issues/59): calls to `unsetActiveROD()` when pressing the buttons

### Platform, compiler and libraries versions

- Windows 10
- Microsoft Visual Studio Compiler 2017 64 bits
- Qt5.9.1
- VTK 8.0.0
- ITK 4.12.0
- Boost 1.64
- OpenCV 3.2.0
- CMake 3.8.2