### PR TITLE
Segmentate every slice

### DIFF
--- a/src/GUI/lineSelectionDialog.cpp
+++ b/src/GUI/lineSelectionDialog.cpp
@@ -20,6 +20,14 @@ void LineSelectionDialog::setImage(std::string filename) {
 	ui->image->setMask(pixmap.mask());
 }
 
+bool LineSelectionDialog::getCompleteUp() const {
+	return ui->completeUp->isChecked();
+}
+
+bool LineSelectionDialog::getCompleteDown() const {
+	return ui->completeDown->isChecked();
+}
+
 void LineSelectionDialog::accept() {
 	if (ui->greenRadioButton->isChecked()) {
 		done(LINE_GREEN);

--- a/src/GUI/lineSelectionDialog.h
+++ b/src/GUI/lineSelectionDialog.h
@@ -42,6 +42,18 @@ public:
 	 */
 	void setImage(std::string filename);
 
+	/**
+	 * Check if it is forced to segmentate every slice to the top
+	 * @return	Force or not to segmentate every slice to the top
+	 */
+	bool getCompleteUp() const;
+
+	/**
+	 * Check if it is forced to segmentate every slice to the bottom
+	 * @return	Force or not to segmentate every slice to the bottom
+	 */
+	bool getCompleteDown() const;
+
 private slots:
 	/**
 	 * Ok button selected

--- a/src/GUI/lineselectiondialog.ui
+++ b/src/GUI/lineselectiondialog.ui
@@ -20,25 +20,6 @@
    <string>Selección de línea</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" rowspan="2" colspan="2">
-    <widget class="QLabel" name="image">
-     <property name="minimumSize">
-      <size>
-       <width>500</width>
-       <height>500</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>500</width>
-       <height>500</height>
-      </size>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="2">
     <widget class="QGroupBox" name="linesGroupBox">
      <property name="maximumSize">
@@ -102,7 +83,26 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="0" column="0" rowspan="4" colspan="2">
+    <widget class="QLabel" name="image">
+     <property name="minimumSize">
+      <size>
+       <width>500</width>
+       <height>500</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>500</width>
+       <height>500</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -115,7 +115,14 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="0">
+   <item row="4" column="1">
+    <widget class="QPushButton" name="cancelButton">
+     <property name="text">
+      <string>Cancelar</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -128,17 +135,30 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="1">
-    <widget class="QPushButton" name="cancelButton">
+   <item row="4" column="2">
+    <widget class="QPushButton" name="okButton">
      <property name="text">
-      <string>Cancelar</string>
+      <string>OK</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QCheckBox" name="completeUp">
+     <property name="text">
+      <string>Hasta arriba</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
    <item row="2" column="2">
-    <widget class="QPushButton" name="okButton">
+    <widget class="QCheckBox" name="completeDown">
      <property name="text">
-      <string>OK</string>
+      <string>Hasta abajo</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/src/Interactor/interactorStyleSegmentation.cpp
+++ b/src/Interactor/interactorStyleSegmentation.cpp
@@ -89,7 +89,7 @@ void InteractorStyleSegmentation::OnLeftButtonDown() {
 					}
 				}
 
-				regionGrowingWithLineBoundVolume(sculpture->getImageData(), segmentedData, sculpture->getTransferFunction()->getColorFun(), ijk, bounds, selectedLine, lines, true, true);
+				regionGrowingWithLineBoundVolume(sculpture->getImageData(), segmentedData, sculpture->getTransferFunction()->getColorFun(), ijk, bounds, selectedLine, lines, diag->getCompleteUp(), diag->getCompleteDown());
 
 				sculpture->getImageData()->DeepCopy(oldData);
 

--- a/src/Interactor/interactorStyleSegmentation.cpp
+++ b/src/Interactor/interactorStyleSegmentation.cpp
@@ -89,7 +89,7 @@ void InteractorStyleSegmentation::OnLeftButtonDown() {
 					}
 				}
 
-				regionGrowingWithLineBoundVolume(sculpture->getImageData(), segmentedData, sculpture->getTransferFunction()->getColorFun(), ijk, bounds, selectedLine, lines);
+				regionGrowingWithLineBoundVolume(sculpture->getImageData(), segmentedData, sculpture->getTransferFunction()->getColorFun(), ijk, bounds, selectedLine, lines, true, true);
 
 				sculpture->getImageData()->DeepCopy(oldData);
 
@@ -106,32 +106,31 @@ void InteractorStyleSegmentation::OnLeftButtonDown() {
 
 				if (exportSegmentedVolume == QMessageBox::Yes) {
 					QString vtiFile = NULL;
-					while (vtiFile == NULL) {
-						vtiFile = QFileDialog::getSaveFileName(NULL, QObject::tr("Exportar volumen"), QDir(QDir::homePath()).filePath("Sub-volume"), "VTI (*.vti) ;; XML (*.xml)");
+					vtiFile = QFileDialog::getSaveFileName(NULL, QObject::tr("Exportar volumen"), QDir(QDir::homePath()).filePath("Sub-volume"), "VTI (*.vti) ;; XML (*.xml)");
+					if (vtiFile != NULL) {
+						// -- launch progress bar
+						QPointer<QProgressBar> bar = new QProgressBar(0);
+						QPointer<QProgressDialog> progressDialog = new QProgressDialog(0);
+						progressDialog->setWindowTitle(QString("Extrayendo..."));
+						progressDialog->setLabelText(QString::fromLatin1("Extrayendo el modelo"));
+						progressDialog->setWindowIcon(QIcon(":/icons/3DCurator.png"));
+						progressDialog->setWindowFlags(progressDialog->windowFlags() & ~Qt::WindowCloseButtonHint);
+						progressDialog->setCancelButton(0);
+						progressDialog->setBar(bar);
+						progressDialog->show();
+						bar->close();
+						QApplication::processEvents();
+						// -- END launch progress bar
+
+						vtkSmartPointer<vtkXMLImageDataWriter> writer = vtkSmartPointer<vtkXMLImageDataWriter>::New();
+						writer->SetFileName(vtiFile.toUtf8().constData());
+						writer->SetInputData(segmentedData);
+						writer->Write();
+
+						// -- close progress bar
+						progressDialog->close();
+						// -- END close progress bar
 					}
-
-					// -- launch progress bar
-					QPointer<QProgressBar> bar = new QProgressBar(0);
-					QPointer<QProgressDialog> progressDialog = new QProgressDialog(0);
-					progressDialog->setWindowTitle(QString("Extrayendo..."));
-					progressDialog->setLabelText(QString::fromLatin1("Extrayendo el modelo"));
-					progressDialog->setWindowIcon(QIcon(":/icons/3DCurator.png"));
-					progressDialog->setWindowFlags(progressDialog->windowFlags() & ~Qt::WindowCloseButtonHint);
-					progressDialog->setCancelButton(0);
-					progressDialog->setBar(bar);
-					progressDialog->show();
-					bar->close();
-					QApplication::processEvents();
-					// -- END launch progress bar
-
-					vtkSmartPointer<vtkXMLImageDataWriter> writer = vtkSmartPointer<vtkXMLImageDataWriter>::New();
-					writer->SetFileName(vtiFile.toUtf8().constData());
-					writer->SetInputData(segmentedData);
-					writer->Write();
-
-					// -- close progress bar
-					progressDialog->close();
-					// -- END close progress bar
 				}
 			}
 		}

--- a/src/Segmentation/woodSegmentation.h
+++ b/src/Segmentation/woodSegmentation.h
@@ -2,6 +2,7 @@
 #define WOODSEGMENTATION_H
 
 #include <queue>
+#include <set>
 #include <array>
 
 #include <vtkSmartPointer.h>
@@ -109,7 +110,9 @@ std::pair<Line, double> findNearestLine(std::vector<Line> lines, const Line goal
  * @param	bounds		Image bounds
  * @param	firstLine	Initial line
  * @param	lines		Lines for each slice
+ * @param	completeUp	Force to segmentate every slice to the top
+ * @param	completeDown	Force to segmentate every slice to the bottom
  */
-void regionGrowingWithLineBoundVolume(vtkSmartPointer<vtkImageData> inputData, vtkSmartPointer<vtkImageData> outputData, vtkSmartPointer<vtkColorTransferFunction> colorFun, const int ijk[3], const Bounds bounds, const Line firstLine, std::vector<std::vector<Line> > &lines);
+void regionGrowingWithLineBoundVolume(vtkSmartPointer<vtkImageData> inputData, vtkSmartPointer<vtkImageData> outputData, vtkSmartPointer<vtkColorTransferFunction> colorFun, const int ijk[3], const Bounds bounds, const Line firstLine, std::vector<std::vector<Line> > &lines, const bool completeUp, const bool completeDown);
 
 #endif // WOODSEGMENTATION_H

--- a/src/Util/measures.h
+++ b/src/Util/measures.h
@@ -3,10 +3,9 @@
 #define WOOD_ISOVALUE	-750.0	/**< Wood isosurface value */
 #define STUCCO_ISOVALUE -100.0	/**< Stucco isosurface value */
 #define METAL_ISOVALUE	2976.0	/**< Metal isosurface value */
-#define RULES_LIMIT	100	/**< Max number of rules */
 #define MIN_ANGLE	0.5	/**< Min angle for nearest line */
-#define MIN_DISTA	5	/**< Min for nearest line */
-#define LINE_TOLERANCE	5	/**< Line tolerance to check if a point is contained by a line */
+#define MIN_DISTA	1	/**< Min for nearest line */
+#define LINE_TOLERANCE	4	/**< Line tolerance to check if a point is contained by a line */
 #define MIN_WOOD	-750.0	/**< Min wood value for segmentation */
 #define MAX_WOOD	3071.0	/**< Max wood value for segmentation */
 #define AIR_HU		-1000.0	/**< Air value */


### PR DESCRIPTION
### Issues solved with this PR

- [Segmentate every slice](https://github.com/fblupi/3DCurator/issues/37): You can indicate with a checkbox if you want to segmentate every slice (to top and to bottom) using the last plane computed to get the line for the last slices.

### Platform, compiler and libraries versions

- Windows 10
- Microsoft Visual Studio Compiler 2017 64 bits
- Qt5.9.1
- VTK 8.0.0
- ITK 4.12.0
- Boost 1.64
- OpenCV 3.2.0
- CMake 3.8.2